### PR TITLE
Enable builds on Ubuntu 17.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,4 @@ Notes
 -----
 
 * This will build `multichaind`, `multichain-cli` and `multichain-util` in the `src` directory.
-=======
-* This will build `multichaind.exe`, `multichain-cli.exe` and `multichain-util.exe` in the `src` directory.
 


### PR DESCRIPTION

fix for https://www.multichain.com/qa/5107/multichain-build-error
