### PR TITLE
fix setruntimeparam for autosubscribe

### DIFF
--- a/src/rpc/rpcmisc.cpp
+++ b/src/rpc/rpcmisc.cpp
@@ -477,16 +477,16 @@ Value setruntimeparam(const json_spirit::Array& params, bool fHelp)
             if(autosubscribe=="streams")
             {
                 mode |= MC_WMD_AUTOSUBSCRIBE_STREAMS;
-            }
-            if(autosubscribe=="assets")
+            } else if (autosubscribe=="assets")
             {
                 mode |= MC_WMD_AUTOSUBSCRIBE_ASSETS;
-            }
-            if( (autosubscribe=="assets,streams") || (autosubscribe=="streams,assets"))
+            } else if ( (autosubscribe=="assets,streams") || (autosubscribe=="streams,assets"))
             {
                 mode |= MC_WMD_AUTOSUBSCRIBE_STREAMS;
                 mode |= MC_WMD_AUTOSUBSCRIBE_ASSETS;
-            }                
+            } else {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "Should be 'assets', 'streams' or 'assets,streams'");
+            }
             
             if(pwalletTxsMain)
             {


### PR DESCRIPTION
when you call:
{"method": "setruntimeparam", "params": ["autosubscribe", "something"]}
there will be no error

and when you call:
{"method": "getruntimeparams", "params": []}
it will return the line:  "autosubscribe": "something",

So you are able to set an invalid parameter